### PR TITLE
Added fresh parameter and create and delete exceptions

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,12 +1,24 @@
+import type { POJO } from './types';
+
 import { CustomError } from 'ts-custom-error';
 
-class ErrorDB extends CustomError {}
+class ErrorDB extends CustomError {
+  data: POJO;
+  constructor(message: string = '', data: POJO = {}) {
+    super(message);
+    this.data = data;
+  }
+}
 
 class ErrorDBRunning extends ErrorDB {}
 
 class ErrorDBNotRunning extends ErrorDB {}
 
 class ErrorDBDestroyed extends ErrorDB {}
+
+class ErrorDBCreate extends ErrorDB {}
+
+class ErrorDBDelete extends ErrorDB {}
 
 class ErrorDBLevelPrefix extends ErrorDB {}
 
@@ -25,6 +37,8 @@ export {
   ErrorDBRunning,
   ErrorDBNotRunning,
   ErrorDBDestroyed,
+  ErrorDBCreate,
+  ErrorDBDelete,
   ErrorDBLevelPrefix,
   ErrorDBDecrypt,
   ErrorDBParse,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,11 @@ import type { AbstractLevelDOWN, AbstractIterator } from 'abstract-leveldown';
 import type { LevelUp } from 'levelup';
 import type { WorkerManagerInterface } from '@matrixai/workers';
 
+/**
+ * Plain data dictionary
+ */
+type POJO = { [key: string]: any };
+
 interface FileSystem {
   promises: {
     rm: typeof fs.promises.rm;
@@ -94,6 +99,7 @@ interface DBTransaction {
 }
 
 export type {
+  POJO,
   FileSystem,
   Crypto,
   DBWorkerManagerInterface,


### PR DESCRIPTION
### Description

Added the `fresh` parameter and also added `ErrorDBCreate` and `ErrorDBDelete` for when we are doing fs operations.

Also when creating the `dbPath`, we don't create the parent directories automatically. That should be the case.

Also changed to using `this.constructor.name` instead of `'DB'`.

Part of CLI review in https://gitlab.com/MatrixAI/Engineering/Polykey/js-polykey/-/merge_requests/213

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
