### PR TITLE
Fix committing or rollbacking dangling transactions

### DIFF
--- a/tests/DBIterator.test.ts
+++ b/tests/DBIterator.test.ts
@@ -1,4 +1,4 @@
-import type { KeyPath } from '@';
+import type { KeyPath } from '@/types';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';


### PR DESCRIPTION
### Description

In the EFS, we came across a problem where there is a dangling transaction that is still pending. It may be neither committed, nor rollbacked, or it may be in the process of committing or rollbacking.

Either way, when the `DB.stop()` is called, it proceeds to rollback all existing transactions in the transaction reference set.

Ideally, all transactions should be committed or rollbacked before the `await db.stop()` is called. However if there are dangling transactions there should be rollbacked if their status is neither committed or rollbacked, but if they have a particular status, then the `DB.stop` should be waiting for those pending statuses to finish.

Here we introduce a lock to be used between `DBTransaction.destroy`, `DBTransaction.commit` and `DBTransaction.rollback`. The basic idea is for `destroy` to wait on a commit or rollback to finish. This allows one to call `await transaction.destroy()` while the committing or rollbacking is occurring.

However at the same time, if a transaction is pending to commit, but hasn't started committing. It's possible for the `DB.stop()` to already start rollbacking. If this occurs, during the resource release, the transaction will attempt to commit, in that case, an exception still occurs because the transaction is already rollbacked. This is a legitimate exception.

### Issues Fixed

* Related: https://github.com/MatrixAI/js-encryptedfs/pull/74#issuecomment-1220423915

### Tasks

- [x] 1. Ensure that `DB.stop()` only performs `await transaction.rollback` when the transaction is neither committing nor rollbacking. If it is in the middle of comitting or rollbacking then it should just wait for it complete.
- [x] 2. Add a test for dangling transactions for `tests/DBTransaction.test.ts`
- [x] 3. Remove `await this.destroy()` from `DBTransaction.commit` and `DBTransaction.rollback`, this is done automatically be the resource release

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build