### PR TITLE
WIP: Introduce optional dependencies to streamline platform-specific installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "install": "node-gyp-build",
     "prebuild": "node ./scripts/prebuild.js",
     "build": "shx rm -rf ./dist && tsc -p ./tsconfig.build.json",
-    "postversion": "npm install --package-lock-only --ignore-scripts --silent",
+    "version": "node ./scripts/version.js",
+    "prepublishOnly": "node ./scripts/prepublishOnly.js",
     "ts-node": "ts-node",
     "test": "jest",
     "lint": "eslint '{src,tests,scripts,benches}/**/*.{js,ts}'",
@@ -36,6 +37,12 @@
     "@matrixai/workers": "^1.3.7",
     "node-gyp-build": "4.4.0",
     "threads": "^1.6.5"
+  },
+  "optionalDependencies": {
+    "@matrixai/db-darwin-arm64": "5.1.0",
+    "@matrixai/db-darwin-x64": "5.1.0",
+    "@matrixai/db-linux-x64": "5.1.0",
+    "@matrixai/db-win32-x64": "5.1.0"
   },
   "devDependencies": {
     "@swc/core": "^1.3.62",

--- a/scripts/prepublishOnly.js
+++ b/scripts/prepublishOnly.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+/**
+ * This runs before `npm publish` command.
+ * This will take the native objects in `prebuild/`
+ * and create native packages under `prepublishOnly/`.
+ *
+ * For example:
+ *
+ * /prepublishOnly
+ *   /@org
+ *     /name-linux-x64
+ *       /package.json
+ *       /node.napi.node
+ *       /README.md
+ */
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
+const childProcess = require('child_process');
+const packageJSON = require('../package.json');
+
+const platform = os.platform();
+
+/* eslint-disable no-console */
+async function main(argv = process.argv) {
+  argv = argv.slice(2);
+  let tag;
+  let dryRun = false;
+  const restArgs = [];
+  while (argv.length > 0) {
+    const option = argv.shift();
+    let match;
+    if ((match = option.match(/--tag(?:=(.+)|$)/))) {
+      tag = match[1] ?? argv.shift();
+    } else if ((match = option.match(/--dry-run$/))) {
+      dryRun = true;
+    } else {
+      restArgs.push(option);
+    }
+  }
+  if (tag == null) {
+    tag = process.env.npm_config_tag;
+  }
+  const projectRoot = path.join(__dirname, '..');
+  const prebuildPath = path.join(projectRoot, 'prebuild');
+  const prepublishOnlyPath = path.join(projectRoot, 'prepublishOnly');
+  const buildNames = (await fs.promises.readdir(prebuildPath)).filter(
+    (filename) => /^(?:[^-]+)-(?:[^-]+)-(?:[^-]+)$/.test(filename),
+  );
+  if (buildNames.length < 1) {
+    console.error(
+      'You must prebuild at least 1 native object with the filename of `name-platform-arch` before prepublish',
+    );
+    process.exitCode = 1;
+    return process.exitCode;
+  }
+  // Extract out the org name, this may be undefined
+  const orgName = packageJSON.name.match(/^@[^/]+/)?.[0];
+  for (const buildName of buildNames) {
+    // This is `name-platform-arch`
+    const name = path.basename(buildName, '.node');
+    // This is `@org/name-platform-arch`, uses `posix` to force usage of `/`
+    const packageName = path.posix.join(orgName ?? '', name);
+    const constraints = name.match(
+      /^(?:[^-]+)-(?<platform>[^-]+)-(?<arch>[^-]+)$/,
+    );
+    // This will be `prebuild/name-platform-arch.node`
+    const buildPath = path.join(prebuildPath, buildName);
+    // This will be `prepublishOnly/@org/name-platform-arch`
+    const packagePath = path.join(prepublishOnlyPath, packageName);
+    console.error('Packaging:', packagePath);
+    try {
+      await fs.promises.rm(packagePath, {
+        recursive: true,
+      });
+    } catch (e) {
+      if (e.code !== 'ENOENT') throw e;
+    }
+    await fs.promises.mkdir(packagePath, { recursive: true });
+    const nativePackageJSON = {
+      name: packageName,
+      version: packageJSON.version,
+      homepage: packageJSON.homepage,
+      author: packageJSON.author,
+      contributors: packageJSON.contributors,
+      description: packageJSON.description,
+      keywords: packageJSON.keywords,
+      license: packageJSON.license,
+      repository: packageJSON.repository,
+      main: 'node.napi.node',
+      os: [constraints.groups.platform],
+      cpu: [...constraints.groups.arch.split('+')],
+    };
+    const packageJSONPath = path.join(packagePath, 'package.json');
+    console.error(`Writing ${packageJSONPath}`);
+    const packageJSONString = JSON.stringify(nativePackageJSON, null, 2);
+    console.error(packageJSONString);
+    await fs.promises.writeFile(packageJSONPath, packageJSONString, {
+      encoding: 'utf-8',
+    });
+    const packageReadmePath = path.join(packagePath, 'README.md');
+    console.error(`Writing ${packageReadmePath}`);
+    const packageReadme = `# ${packageName}\n`;
+    console.error(packageReadme);
+    await fs.promises.writeFile(packageReadmePath, packageReadme, {
+      encoding: 'utf-8',
+    });
+    const packageBuildPath = path.join(packagePath, 'node.napi.node');
+    console.error(`Copying ${buildPath} to ${packageBuildPath}`);
+    await fs.promises.copyFile(buildPath, packageBuildPath);
+    const publishArgs = [
+      'publish',
+      packagePath,
+      ...(tag != null ? [`--tag=${tag}`] : []),
+      '--access=public',
+      ...(dryRun ? ['--dry-run'] : []),
+    ];
+    console.error('Running npm publish:');
+    console.error(['npm', ...publishArgs].join(' '));
+    childProcess.execFileSync('npm', publishArgs, {
+      stdio: ['inherit', 'inherit', 'inherit'],
+      windowsHide: true,
+      encoding: 'utf-8',
+      shell: platform === 'win32' ? true : false,
+    });
+  }
+}
+/* eslint-enable no-console */
+
+void main();

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * This runs after `npm version` command updates the version but before changes are commited.
+ * This will also update the `package.json` optional native dependencies
+ * to match the same version as the version of this package.
+ * This maintains the same version between this master package
+ * and the optional native dependencies.
+ * At the same time, the `package-lock.json` is also regenerated.
+ * Note that at this point, the new optional native dependencies have
+ * not yet been published, so the `--package-lock-only` flag is used
+ * to prevent `npm` from attempting to download unpublished packages.
+ */
+
+const path = require('path');
+const os = require('os');
+const childProcess = require('child_process');
+const packageJSON = require('../package.json');
+
+const platform = os.platform();
+
+/* eslint-disable no-console */
+async function main() {
+  console.error(
+    'Updating the package.json with optional native dependencies and package-lock.json',
+  );
+  const optionalDepsNative = [];
+  for (const key in packageJSON.optionalDependencies) {
+    if (key.startsWith(packageJSON.name)) {
+      optionalDepsNative.push(`${key}@${packageJSON.version}`);
+    }
+  }
+  if (optionalDepsNative.length > 0) {
+    const installArgs = [
+      'install',
+      '--ignore-scripts',
+      '--silent',
+      '--package-lock-only',
+      '--save-optional',
+      '--save-exact',
+      ...optionalDepsNative,
+    ];
+    console.error('Running npm install:');
+    console.error(['npm', ...installArgs].join(' '));
+    childProcess.execFileSync('npm', installArgs, {
+      stdio: ['inherit', 'inherit', 'inherit'],
+      windowsHide: true,
+      encoding: 'utf-8',
+      shell: platform === 'win32' ? true : false,
+    });
+  }
+}
+/* eslint-enable no-console */
+
+void main();


### PR DESCRIPTION
### Description

Our js-quic now published optional packages 

```
  "optionalDependencies": {
    "@matrixai/quic-darwin-arm64": "0.0.7-alpha.0",
    "@matrixai/quic-darwin-x64": "0.0.7-alpha.0",
    "@matrixai/quic-linux-x64": "0.0.7-alpha.0",
    "@matrixai/quic-win32-x64": "0.0.7-alpha.0"
  },
```

I want to apply this to js-db too, so we can do streamline the installation and also be able to self-publish at least just the Linux one.

This involves replacing how we do our `prebuild.js` in particular and bringing in the `scripts/prebuild.js`, `scripts/prepublishOnly.js` and `scripts/version.js`.

We may also need to fix up our CI/CD scripts too.

Without the GitLab CI/CD we can only do the linux build and windows builds. So we can delay having the macos ones.

Note that we rely on `node-gyp-build` package for both detection and auto-building the local dependency when installed. We don't have `node-gyp-build` in `js-quic`, thus there's no automatic compilation upon installation. Instead if none of the native dependencies can be found, it's necessary for the user to compile their own (which is a bit of a pain)... since compilation requires running a certain script, specifically `npm run prebuild`. However that's not really possible while we are installing `js-quic` as a dependency. We could do something similar with our own install script, but such a script/command has to exist in the packaged distribution and we actually ignore all `/scripts` in our `.npmignore`.

At the end of the day, I'm not even sure if it makes sense to enable automatic compilation. Really if it is not available, they have to source it from somewhere and place it in the right location. Specifically the custom loader will look for it in just the local `prebuild/` directory. So figure out a compilation routine and then distribute it during `npm install`. The problem with relying on `npm install` to compile the native binary is that there's no guarantee that all the tools are available to do this for the end user. So therefore one should think of `npm install` as the final distribution here, for power users, they should be using the gitlab repository, possibly directly refer to it as a dependency, or submit a build for this opensource repo.

### Tasks

- [ ] 1. Bring in scripts from `js-quic`
- [ ] 2. Run a compilation on Linux
- [ ] 3. Replace the `node-gyp-build` with just your own loader script, copied from `js-quic`.
- [ ] 4. Remove the `install` command of `node-gyp-build`. It would not be necessary... as it simply detects if the binary already exists, and if not ends up calling a build to do a local compilation.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
